### PR TITLE
Do not remove Googletest during make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ prefix=/usr/local
 all: clean test
 
 clean:
-	rm -rf ./bin googletest-*.zip
+	rm -rf ./bin
 
 configure:
 	mkdir -p ./bin


### PR DESCRIPTION
Now it looks like this:
```
   $ cd pmemkv-jni
   $ cp /opt/googletest/googletest-1.7.0.zip .
   $ make
   rm -rf ./bin googletest-*.zip
```
so 'make' removes Googletest copied from the Docker image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-jni/18)
<!-- Reviewable:end -->
